### PR TITLE
changed per simulated partilce to per source particle

### DIFF
--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -5,9 +5,6 @@ name: CI with install
 
 on:
   pull_request:
-    branches:
-      - develop
-      - main
     paths-ignore:
       - 'docs/**'
       - '.gitignore'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ pip install openmc_tally_unit_converter
 
 OpenMC tally results are save into a statepoint h5 file without units.
 
-This package ascertains the base units of common tallies by inspecting their tally filters and scores.
+This package ascertains the base units of common tallies by inspecting their
+tally filters and scores.
+
+The following worked example is for a heating tally. Flux, effective dose and
+DPA / damage-energy tallies are also supported.
 
 ```python
 import openmc_tally_unit_converter as otuc
@@ -24,7 +28,7 @@ my_tally = statepoint.get_tally(name="my_cell_heating_tally")
 # gets the base units of the tally
 tally = otuc.process_tally(tally=my_tally)
 print(tally)
->>> eV per source_particle
+>>> 218559.22320927 electron_volt / source_particle
 ```
 
 The package then allows users to scale the base tally units to different units. For example the package can easily convert cm to meters or electron volts to joules.
@@ -32,17 +36,41 @@ The package then allows users to scale the base tally units to different units. 
 ```python
 converted_tally = otuc.process_tally(
     tally=my_tally,
-    required_units = Joules / source_particle
+    required_units = "joules / source_particle"
 )
 
 print(converted_tally)
->>> 2.4e-12 Joules per source_particle
+>>> 3.50170481e-14 Joules / source_particle
 ```
 
-Additional inputs can be applied to normalize the the tallies and convert the units further:
+Additional inputs can be applied to normalize the the tallies and convert the
+units further:
 
-- The source strength of the source in particles per second can be specified with the ```strength_strength``` argument. This allows the tally results to be converted from the units of score per simulated particle to score per second.
+- The source strength of the source in particles per second can be specified with the ```strength_strength``` argument. This allows the tally results to be converted from the units of score per simulated particle to score per unit time (e.g seconds, hours, days etc).
+
+```python
+converted_tally = otuc.process_tally(
+    tally=my_tally,
+    source_strength=1e20,  # input units for this argument are particles per second
+    required_units = "joules / minute"
+)
+
+print(converted_tally)
+>>> 2.10102288e+08 joules / source_particle
+```
 
 - The volume of the cell in cm3 can also be specified with the ```volume``` argument. This allows the tally result to be converted from the base units to base units per unit volume.
+
+```python
+converted_tally = otuc.process_tally(
+    tally=my_tally,
+    source_strength=13458.3,  # input units for this argument are particles per second
+    volume=12,  # input units are in cm3
+    required_units = "joules / second / meter **3"
+)
+
+print(converted_tally)
+>>> 3.92724948e-05 Joules / meter ** 3 / second
+```
 
 :point_right: [Further examples](https://github.com/fusion-energy/openmc_tally_unit_converter/tree/main/examples)

--- a/examples/example_from_readme.ipynb
+++ b/examples/example_from_readme.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "14df8c6a-6b0a-44d3-b90c-74ee6ff6b820",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openmc_tally_unit_converter as otuc\n",
+    "import openmc\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b1934d79-befd-4c38-b693-725f5c09d6eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "statepoint = openmc.StatePoint(filepath=\"statepoint.2.h5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8105aaca-2571-4259-90b6-d3379ed89fcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_tally = statepoint.get_tally(name=\"2_heating\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "57d63abe-329d-4bc4-903d-3c123b98fee3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(<Quantity([218559.22320927], 'electron_volt / source_particle')>, <Quantity([92.23598504], 'electron_volt / source_particle')>)\n"
+     ]
+    }
+   ],
+   "source": [
+    "tally = otuc.process_tally(\n",
+    "    tally=my_tally,\n",
+    "    required_units='eV / source_particle'\n",
+    ")\n",
+    "print(tally)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "78144320-72aa-4bac-b293-063afe44692e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(<Quantity([3.50170481e-14], 'joule / source_particle')>, <Quantity([1.4777834e-17], 'joule / source_particle')>)\n"
+     ]
+    }
+   ],
+   "source": [
+    "converted_tally = otuc.process_tally(\n",
+    "    tally=my_tally,\n",
+    "    required_units = \"joules / source_particle\"\n",
+    ")\n",
+    "\n",
+    "print(converted_tally)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "060131bb-2c02-4fad-bdf9-2efabd05a988",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(<Quantity([2.10102288e+08], 'joule / minute')>, <Quantity([88667.00402725], 'joule / minute')>)\n"
+     ]
+    }
+   ],
+   "source": [
+    "converted_tally = otuc.process_tally(\n",
+    "    tally=my_tally,\n",
+    "    source_strength=1e20,  # input units for this argument are particles per second\n",
+    "    required_units = \"joules / minute\"\n",
+    ")\n",
+    "\n",
+    "print(converted_tally)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "36846a7b-af7a-4e6b-bb4e-58017f80ecee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([3.92724948e-05]) <Unit('joule / meter ** 3 / second')>,\n",
+       " array([1.65737103e-08]) <Unit('joule / meter ** 3 / second')>)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "converted_tally = otuc.process_tally(\n",
+    "    tally=my_tally,\n",
+    "    source_strength=13458.3,  # input units for this argument are particles per second\n",
+    "    volume=12,  # input units are in cm3\n",
+    "    required_units = \"joules / second / meter **3\"\n",
+    ")\n",
+    "converted_tally"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52ad3f34-e0cd-4f03-aa70-e15086fef33e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/processing_2d_mesh_effective_dose_tally.py
+++ b/examples/processing_2d_mesh_effective_dose_tally.py
@@ -17,7 +17,7 @@ print(f"mesh tally results {tally_result}", end="\n\n")
 
 # scaled from picosievert to sievert
 tally_result, std_dev_result = otuc.process_dose_tally(
-    tally=my_tally, required_units="sievert / simulated_particle"
+    tally=my_tally, required_units="sievert / source_particle"
 )
 # the tally result with required units
 print(f"converted mesh tally results {tally_result}")

--- a/examples/processing_cell_damage-energy_tally.py
+++ b/examples/processing_cell_damage-energy_tally.py
@@ -10,7 +10,7 @@ my_tally = statepoint.get_tally(name="2_damage-energy")
 
 # returns the tally with base units
 result = otuc.process_damage_energy_tally(
-    tally=my_tally, required_units="eV / simulated_particle"
+    tally=my_tally, required_units="eV / source_particle"
 )
 print(f"damage-energy base units = {result}", end="\n\n")
 
@@ -18,7 +18,7 @@ print(f"damage-energy base units = {result}", end="\n\n")
 # returns the tally with scalled based units (MeV instead of eV)
 result, std_dev = otuc.process_damage_energy_tally(
     tally=my_tally,
-    required_units="MeV / simulated_particle"
+    required_units="MeV / source_particle"
     # required_units="displacements per atoms"
 )
 print(f"damage-energy scaled base units = {result}", end="\n\n")

--- a/examples/processing_cell_effective_dose_tally.py
+++ b/examples/processing_cell_effective_dose_tally.py
@@ -14,7 +14,7 @@ print(f"effective dose tally = {tally_result}", end="\n\n")
 
 # returns the tally with scalled based units (MeV instead of eV)
 tally_result, std_dev_result = otuc.process_dose_tally(
-    tally=my_tally, required_units="sievert / simulated_particle"
+    tally=my_tally, required_units="sievert / source_particle"
 )
 print(f"effective dose scaled base units = {tally_result}", end="\n\n")
 

--- a/examples/processing_cell_flux_tally.py
+++ b/examples/processing_cell_flux_tally.py
@@ -11,14 +11,14 @@ my_tally = statepoint.get_tally(name="2_flux")
 
 # returns the tally with base units
 result = otuc.process_tally(
-    tally=my_tally, required_units="centimeter / simulated_particle"
+    tally=my_tally, required_units="centimeter / source_particle"
 )
 print(f"flux base units = {result[0].units}", end="\n\n")
 
 
 # returns the tally with scalled based units (m instead of cm)
 result = otuc.process_tally(
-    tally=my_tally, required_units="centimeter * particle / simulated_particle"
+    tally=my_tally, required_units="centimeter * particle / source_particle"
 )
 print(f"flux scaled base units = {result[0].units}", end="\n\n")
 

--- a/examples/processing_cell_heating_tally.py
+++ b/examples/processing_cell_heating_tally.py
@@ -9,12 +9,12 @@ my_tally = statepoint.get_tally(name="2_heating")
 
 
 # returns the tally with base units
-result = otuc.process_tally(tally=my_tally, required_units="eV / simulated_particle")
+result = otuc.process_tally(tally=my_tally, required_units="eV / source_particle")
 print(f"heating base units = {result}", end="\n\n")
 
 
 # returns the tally with scalled based units (MeV instead of eV)
-result = otuc.process_tally(tally=my_tally, required_units="MeV / simulated_particle")
+result = otuc.process_tally(tally=my_tally, required_units="MeV / source_particle")
 print(f"heating scalled base units = {result}", end="\n\n")
 
 

--- a/examples/processing_mutliple_cell_spectra_tally.py
+++ b/examples/processing_mutliple_cell_spectra_tally.py
@@ -14,13 +14,13 @@ results["3_neutron_spectra"] = statepoint.get_tally(name="3_neutron_spectra")
 plot = plot_spectrum_from_tally(
     spectrum=results,
     x_label="Energy [eV]",
-    y_label="neutron flux [centimeters / simulated_particle]",
+    y_label="neutron flux [centimeters / source_particle]",
     x_scale="log",
     y_scale="log",
     filename="combine_spectra_plot_1.html",
     required_energy_units="eV",
     plotting_package="plotly",
-    required_units="centimeters / simulated_particle",
+    required_units="centimeters / source_particle",
 )
 
 

--- a/openmc_tally_unit_converter/neutronics_units.txt
+++ b/openmc_tally_unit_converter/neutronics_units.txt
@@ -4,7 +4,7 @@
 particle = []
 neutron = []
 photon = []
-simulated_particle = []
+source_particle = []
 atom = [atom]
 displacements = [displacements]
 pulse = [pulse]

--- a/openmc_tally_unit_converter/utils.py
+++ b/openmc_tally_unit_converter/utils.py
@@ -12,7 +12,7 @@ ureg.load_definitions(str(Path(__file__).parent / "neutronics_units.txt"))
 
 def process_damage_energy_tally(
     tally,
-    required_units: str = "eV / simulated_particle",
+    required_units: str = "eV / source_particle",
     source_strength: float = None,
     volume: float = None,
     energy_per_displacement: float = None,
@@ -108,7 +108,7 @@ def process_damage_energy_tally(
 
 def process_spectra_tally(
     tally,
-    required_units: str = "centimeters / simulated_particle",
+    required_units: str = "centimeters / source_particle",
     required_energy_units: str = "eV",
     source_strength: float = None,
     volume: float = None,
@@ -184,7 +184,7 @@ def process_spectra_tally(
 
 def process_dose_tally(
     tally,
-    required_units: str = "picosievert / simulated_particle",
+    required_units: str = "picosievert / source_particle",
     source_strength: float = None,
     volume: float = None,
 ):
@@ -216,7 +216,7 @@ def process_dose_tally(
     base_units = base_units * ureg.picosievert / ureg.centimeter
 
     # dose coefficients are flux to does coefficients and have units of picoSievert / cm
-    # flux has particle ureg.centimeter / simulated_particle units
+    # flux has particle ureg.centimeter / source_particle units
     # dose on a volume uses a flux score (units of cm per simulated particle) and therefore gives pSv / simulated particle
 
     data_frame = tally.get_pandas_dataframe()
@@ -552,21 +552,21 @@ def get_score_units(tally):
 
     if tally.scores == ["current"]:
         units = get_particles_from_tally_filters(tally, ureg)
-        units = units / (ureg.simulated_particle)
+        units = units / (ureg.source_particle)
 
     elif tally.scores == ["flux"]:
-        # tally has units of particle-cm2 per simulated_particle
+        # tally has units of particle-cm2 per source_particle
         # https://openmc.discourse.group/t/normalizing-tally-to-get-flux-value/99/4
         units = get_particles_from_tally_filters(tally, ureg)
-        units = units * ureg.centimeter / ureg.simulated_particle
+        units = units * ureg.centimeter / ureg.source_particle
 
     elif tally.scores == ["heating"]:
-        # heating units are eV / simulated_particle
-        units = ureg.electron_volt / ureg.simulated_particle
+        # heating units are eV / source_particle
+        units = ureg.electron_volt / ureg.source_particle
 
     elif tally.scores == ["damage-energy"]:
-        # damage-energy units are eV / simulated_particle
-        units = ureg.electron_volt / ureg.simulated_particle
+        # damage-energy units are eV / source_particle
+        units = ureg.electron_volt / ureg.source_particle
 
     else:
         msg = (

--- a/tests/test_cell_damage_energy.py
+++ b/tests/test_cell_damage_energy.py
@@ -15,12 +15,12 @@ class TestUsage(unittest.TestCase):
     def test_energy_no_processing(self):
         # returns the tally with base units
         result = otuc.process_damage_energy_tally(
-            tally=self.my_tally, required_units="eV / simulated_particle"
+            tally=self.my_tally, required_units="eV / source_particle"
         )
 
         assert len(result) == 2
-        assert result[0].units == "electron_volt / simulated_particle"
-        assert result[1].units == "electron_volt / simulated_particle"
+        assert result[0].units == "electron_volt / source_particle"
+        assert result[1].units == "electron_volt / source_particle"
         assert isinstance(result[0][0].magnitude, float)
         assert isinstance(result[1][0].magnitude, float)
 
@@ -111,14 +111,14 @@ class TestUsage(unittest.TestCase):
 
         result = otuc.process_damage_energy_tally(
             tally=self.my_tally,
-            required_units="MeV / simulated_particle / atom",
+            required_units="MeV / source_particle / atom",
             volume=5,
             material=my_mat,
         )
 
         assert len(result) == 2
-        assert result[0].units == "megaelectron_volt / atom / simulated_particle"
-        assert result[1].units == "megaelectron_volt / atom / simulated_particle"
+        assert result[0].units == "megaelectron_volt / atom / source_particle"
+        assert result[1].units == "megaelectron_volt / atom / source_particle"
 
     def test_energy_per_second_per_atom(self):
         """makes use of material and volume to convert to per atom units"""
@@ -139,7 +139,7 @@ class TestUsage(unittest.TestCase):
         assert result[0].units == "megaelectron_volt / atom / second"
         assert result[1].units == "megaelectron_volt / atom / second"
 
-    def test_displacements_per_simulated_particle(self):
+    def test_displacements_per_source_particle(self):
         """makes use of energy_per_displacement to convert to displacements units"""
 
         my_mat = openmc.Material()
@@ -148,13 +148,13 @@ class TestUsage(unittest.TestCase):
 
         result = otuc.process_damage_energy_tally(
             tally=self.my_tally,
-            required_units="displacements / simulated_particle",
+            required_units="displacements / source_particle",
             energy_per_displacement=80,
         )
 
         assert len(result) == 2
-        assert result[0].units == "displacements / simulated_particle"
-        assert result[1].units == "displacements / simulated_particle"
+        assert result[0].units == "displacements / source_particle"
+        assert result[1].units == "displacements / source_particle"
 
     def test_displacements_per_second(self):
         """makes use of energy_per_displacement to get displacements per second"""

--- a/tests/test_cell_effective_dose.py
+++ b/tests/test_cell_effective_dose.py
@@ -24,7 +24,7 @@ class TestUsage(unittest.TestCase):
         )
 
         assert len(result) == 1
-        assert result[0].units == "picosievert / simulated_particle"
+        assert result[0].units == "picosievert / source_particle"
 
     def test_cell_tally_dose_no_processing(self):
         # returns the tally with base units
@@ -32,17 +32,17 @@ class TestUsage(unittest.TestCase):
             tally=self.my_tally,
         )
         assert len(result) == 2
-        assert result[0].units == "picosievert / simulated_particle"
-        assert result[1].units == "picosievert / simulated_particle"
+        assert result[0].units == "picosievert / source_particle"
+        assert result[1].units == "picosievert / source_particle"
 
     def test_cell_tally_dose_processing_with_scaling(self):
 
         result = otuc.process_dose_tally(
-            tally=self.my_tally, required_units="sievert / simulated_particle"
+            tally=self.my_tally, required_units="sievert / source_particle"
         )
         assert len(result) == 2
-        assert result[0].units == "sievert / simulated_particle"
-        assert result[1].units == "sievert / simulated_particle"
+        assert result[0].units == "sievert / source_particle"
+        assert result[1].units == "sievert / source_particle"
 
     def test_cell_tally_dose_with_pulse_processing(self):
         result = otuc.process_dose_tally(

--- a/tests/test_cell_flux.py
+++ b/tests/test_cell_flux.py
@@ -19,22 +19,22 @@ class TestUsage(unittest.TestCase):
 
         result = otuc.process_tally(
             tally=self.my_tally_2,
-            required_units="centimeter / simulated_particle",
+            required_units="centimeter / source_particle",
         )
 
         assert len(result) == 1
-        assert result[0].units == "centimeter / simulated_particle"
+        assert result[0].units == "centimeter / source_particle"
 
     def test_cell_tally_flux_no_processing(self):
 
         result = otuc.process_tally(
             tally=self.my_tally,
-            required_units="centimeter / simulated_particle",
+            required_units="centimeter / source_particle",
         )
 
         assert len(result) == 2
-        assert result[0].units == "centimeter / simulated_particle"
-        assert result[1].units == "centimeter / simulated_particle"
+        assert result[0].units == "centimeter / source_particle"
+        assert result[1].units == "centimeter / source_particle"
 
     def test_cell_tally_flux_fusion_power_processing(self):
 

--- a/tests/test_cell_heating.py
+++ b/tests/test_cell_heating.py
@@ -15,12 +15,12 @@ class TestUsage(unittest.TestCase):
     def test_cell_tally_heating_no_processing(self):
         # returns the tally with base units
         result = otuc.process_tally(
-            tally=self.my_tally, required_units="eV / simulated_particle"
+            tally=self.my_tally, required_units="eV / source_particle"
         )
 
         assert len(result) == 2
-        assert result[0].units == "electron_volt / simulated_particle"
-        assert result[1].units == "electron_volt / simulated_particle"
+        assert result[0].units == "electron_volt / source_particle"
+        assert result[1].units == "electron_volt / source_particle"
         assert isinstance(result[0][0].magnitude, float)
         assert isinstance(result[1][0].magnitude, float)
 

--- a/tests/test_cell_spectra.py
+++ b/tests/test_cell_spectra.py
@@ -20,7 +20,7 @@ class TestUsage(unittest.TestCase):
         # units for energy
         assert result[0].units == "electron_volt"
         # units for flux
-        assert result[1].units == "centimeter / simulated_particle"
+        assert result[1].units == "centimeter / source_particle"
 
     def test_cell_tally_spectra_pulse_processing(self):
 


### PR DESCRIPTION
To be more consistent with OpenMC documentation the ```per simulated_particle``` has been changed to ```per source particle```