### PR TITLE
Adding tests for local heating

### DIFF
--- a/.github/workflows/ci_with_install.yml
+++ b/.github/workflows/ci_with_install.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           python tests/create_statepoint_file_for_testing.py --batches 2 --particles 100
           python tests/create_statepoint_file_for_testing.py --batches 1 --particles 100
-          pytest tests/ -v --cov=openmc_tally_unit_converter --cov-append --cov-report term --cov-report xml
+          pytest tests -v --cov=openmc_tally_unit_converter --cov-append --cov-report term --cov-report xml
 
       - name: Run examples
         run: |

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ OpenMC tally results are save into a statepoint h5 file without units.
 This package ascertains the base units of common tallies by inspecting their
 tally filters and scores.
 
-The following worked example is for a heating tally. Flux, effective dose and
-DPA / damage-energy tallies are also supported.
+The following worked example is for a heating tally. Other supported tallies are heating-local, flux, effective dose and DPA / damage-energy tallies are also supported.
 
 ```python
 import openmc_tally_unit_converter as otuc

--- a/tests/create_statepoint_file_for_testing.py
+++ b/tests/create_statepoint_file_for_testing.py
@@ -140,12 +140,12 @@ tally15 = odw.CellTally(
 tally16 = odw.MeshTally2D(
     tally_type="neutron_effective_dose",
     plane="xy",
-    mesh_resolution=(10, 5),
+    mesh_resolution=(2, 3),
     bounding_box=[(-500, -500, 0), (500, 500, 1)],
 )
 
 tally17 = odw.MeshTally3D(
-    mesh_resolution=(500, 500, 500),
+    mesh_resolution=(2, 3, 4),
     bounding_box=[(-500, -500, 0), (500, 500, 1)],
     tally_type="neutron_effective_dose",
 )


### PR DESCRIPTION
reduced the size of the mesh tally